### PR TITLE
PURPLEX-985: Allow adding a stream to existing connection

### DIFF
--- a/src/awrtc/media_browser/BrowserMediaNetwork.ts
+++ b/src/awrtc/media_browser/BrowserMediaNetwork.ts
@@ -212,6 +212,17 @@ export class BrowserMediaNetwork extends WebRtcNetwork implements IMediaNetwork 
                     //unlike native version this one will happily play the local sound causing an echo
                     //set to mute
                     this.mLocalStream.SetMute(true);
+
+                    // if we're setting up new stream to already running connection,
+                    // we have to add the stream to existing peers and re-send the offer
+                    for (const connectioId in this.IdToConnection) {
+                        const peer = this.IdToConnection[connectioId] as MediaPeer;
+                        if (peer !== null) {
+                            peer.AddLocalStream(stream);
+                            peer.CreateOffer();
+                        }
+                    }
+
                     this.OnConfigurationSuccess();
 
                 });

--- a/src/awrtc/network/WebRtcNetwork.ts
+++ b/src/awrtc/network/WebRtcNetwork.ts
@@ -205,10 +205,11 @@ export class WebRtcNetwork implements IBasicNetwork {
                 this.mSignalingNetwork.SendData(new ConnectionId(+key), buffer, true);
             }
 
-            if (peer.GetState() == WebRtcPeerState.Connected) {
+            // ignore peers in connected state which have been already added
+            if (peer.GetState() == WebRtcPeerState.Connected && !this.mIdToConnection[peer.ConnectionId.id]) {
                 connected.push(peer.SignalingInfo.ConnectionId);
             }
-            else if (peer.GetState() == WebRtcPeerState.SignalingFailed || timeAlive > this.mTimeout) {
+            else if (peer.GetState() == WebRtcPeerState.SignalingFailed) {
                 failed.push(peer.SignalingInfo.ConnectionId);
             }
         }
@@ -336,9 +337,6 @@ export class WebRtcNetwork implements IBasicNetwork {
     
     private ConnectionEstablished(signalingConId: ConnectionId): void {
         let peer = this.mInSignaling[signalingConId.id];
-
-        delete this.mInSignaling[signalingConId.id];
-        this.mSignalingNetwork.Disconnect(signalingConId);
 
         this.mConnectionIds.push(peer.ConnectionId);
         this.mIdToConnection[peer.ConnectionId.id] = peer;

--- a/src/awrtc/network/WebRtcPeer.ts
+++ b/src/awrtc/network/WebRtcPeer.ts
@@ -182,11 +182,10 @@ export abstract class AWebRtcPeer {
 
     public Update(): void {
 
-        if (this.mState != WebRtcPeerState.Closed && this.mState != WebRtcPeerState.Closing && this.mState != WebRtcPeerState.SignalingFailed)
+        if (this.mState != WebRtcPeerState.Closed && this.mState != WebRtcPeerState.Closing && this.mState != WebRtcPeerState.SignalingFailed) {
             this.UpdateState();
-
-        if (this.mState == WebRtcPeerState.Signaling || this.mState == WebRtcPeerState.Created)
             this.HandleIncomingSignaling();
+        }
     }
 
     private UpdateState(): void {
@@ -312,7 +311,7 @@ export abstract class AWebRtcPeer {
         this.EnqueueOutgoing("" + nb);
     }
 
-    private CreateOffer(): void {
+    public CreateOffer(): void {
         Debug.Log("CreateOffer");
 
         


### PR DESCRIPTION
I'm not sure if the re-connecting really is faster, if we don't kill the WebRTC stream completely, we're still able to send mouse and keyboard events to the URL asset. Otherwise it's a bit weird for the user that some events propagated to the asset and some didn't.

And the changes we do with those events are rendered back with a screenshot in the mean time before video stream starts.